### PR TITLE
Add support for connected component traversal & reset

### DIFF
--- a/tests/external_undo_log.rs
+++ b/tests/external_undo_log.rs
@@ -5,7 +5,7 @@ extern crate ena;
 use ena::{
     snapshot_vec as sv,
     undo_log::{Rollback, Snapshots, UndoLogs},
-    unify::{self as ut, EqUnifyValue, UnifyKey},
+    unify::{self as ut, EqUnifyValue, NoExtraTraversalData, UnifyKey},
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -27,12 +27,12 @@ impl UnifyKey for IntKey {
 impl EqUnifyValue for IntKey {}
 
 enum UndoLog {
-    EqRelation(sv::UndoLog<ut::Delegate<IntKey>>),
+    EqRelation(sv::UndoLog<ut::Delegate<IntKey, NoExtraTraversalData>>),
     Values(sv::UndoLog<i32>),
 }
 
-impl From<sv::UndoLog<ut::Delegate<IntKey>>> for UndoLog {
-    fn from(l: sv::UndoLog<ut::Delegate<IntKey>>) -> Self {
+impl From<sv::UndoLog<ut::Delegate<IntKey, NoExtraTraversalData>>> for UndoLog {
+    fn from(l: sv::UndoLog<ut::Delegate<IntKey, NoExtraTraversalData>>) -> Self {
         UndoLog::EqRelation(l)
     }
 }
@@ -55,7 +55,6 @@ impl Rollback<UndoLog> for TypeVariableStorage {
 #[derive(Default)]
 struct TypeVariableStorage {
     values: sv::SnapshotVecStorage<i32>,
-
     eq_relations: ut::UnificationTableStorage<IntKey>,
 }
 


### PR DESCRIPTION
Some projects need the connected component traversal feature.

However, that feature was removed from *ena* for performance reasons: preserving the data required for connected component traversal introduced an overhead that was unnecessary in the large majority of cases. (d0a897589c5854a3557bc0c0d2fe675b4156cedb)

This PR reintroduces this as an optional feature through a type parameter on the `UnificationStore`.

Because no extra data is stored when not using `ConnectedComponentTraversal`, this feature has no impact on performance when not used.

**Benchmarks:**
master:
```
test unify::tests::big_array_bench_InPlace             ... bench:     499,038 ns/iter (+/- 2,306)
test unify::tests::big_array_bench_clone_InPlace       ... bench:     614,115 ns/iter (+/- 2,672)
test unify::tests::big_array_bench_in_snapshot_InPlace ... bench:     741,977 ns/iter (+/- 24,403)
```
this branch:
```
test unify::tests::big_array_bench_InPlace             ... bench:     467,384 ns/iter (+/- 10,037)
test unify::tests::big_array_bench_clone_InPlace       ... bench:     571,047 ns/iter (+/- 3,150)
test unify::tests::big_array_bench_in_snapshot_InPlace ... bench:     740,714 ns/iter (+/- 7,666)
```

Compared to a feature, this design enables the library to be used simultaneously in both cases (connected component traversal required and not required), while benefiting from optimal performance in both cases.