### PR TITLE
Use `core::convert::Infallible` instead of a custom `NoError` struct

### DIFF
--- a/src/unify/tests.rs
+++ b/src/unify/tests.rs
@@ -19,7 +19,7 @@ use self::test::Bencher;
 use std::cmp;
 #[cfg(feature = "persistent")]
 use unify::Persistent;
-use unify::{EqUnifyValue, InPlace, InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
+use unify::{EqUnifyValue, InPlace, InPlaceUnificationTable, Infallible, UnifyKey, UnifyValue};
 use unify::{UnificationStore, UnificationTable};
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
@@ -397,9 +397,9 @@ impl UnifyKey for OrderedKey {
 }
 
 impl UnifyValue for OrderedRank {
-    type Error = NoError;
+    type Error = Infallible;
 
-    fn unify_values(value1: &Self, value2: &Self) -> Result<Self, NoError> {
+    fn unify_values(value1: &Self, value2: &Self) -> Result<Self, Infallible> {
         Ok(OrderedRank(cmp::max(value1.0, value2.0)))
     }
 }


### PR DESCRIPTION
That is more future-proof, and will integrate better with other crates.