### PR TITLE
Use usize indexes

### DIFF
--- a/src/unify/backing_vec.rs
+++ b/src/unify/backing_vec.rs
@@ -27,7 +27,7 @@ pub trait UnificationStoreBase: ops::Index<usize, Output = VarValue<Key<Self>>> 
 }
 
 pub trait UnificationStoreMut: UnificationStoreBase {
-    fn reset_unifications(&mut self, value: impl FnMut(u32) -> VarValue<Self::Key>);
+    fn reset_unifications(&mut self, value: impl FnMut(usize) -> VarValue<Self::Key>);
 
     fn push(&mut self, value: VarValue<Self::Key>);
 
@@ -90,8 +90,8 @@ where
     L: UndoLogs<sv::UndoLog<Delegate<K>>>,
 {
     #[inline]
-    fn reset_unifications(&mut self, mut value: impl FnMut(u32) -> VarValue<Self::Key>) {
-        self.values.set_all(|i| value(i as u32));
+    fn reset_unifications(&mut self, mut value: impl FnMut(usize) -> VarValue<Self::Key>) {
+        self.values.set_all(|i| value(i));
     }
 
     #[inline]
@@ -199,12 +199,12 @@ impl<K: UnifyKey> UnificationStoreBase for Persistent<K> {
 #[cfg(feature = "persistent")]
 impl<K: UnifyKey> UnificationStoreMut for Persistent<K> {
     #[inline]
-    fn reset_unifications(&mut self, mut value: impl FnMut(u32) -> VarValue<Self::Key>) {
+    fn reset_unifications(&mut self, mut value: impl FnMut(usize) -> VarValue<Self::Key>) {
         // Without extending dogged, there isn't obviously a more
         // efficient way to do this. But it's pretty dumb. Maybe
         // dogged needs a `map`.
         for i in 0..self.values.len() {
-            self.values[i] = value(i as u32);
+            self.values[i] = value(i);
         }
     }
 

--- a/src/unify/mod.rs
+++ b/src/unify/mod.rs
@@ -63,9 +63,9 @@ mod tests;
 pub trait UnifyKey: Copy + Clone + Debug + PartialEq {
     type Value: UnifyValue;
 
-    fn index(&self) -> u32;
+    fn index(&self) -> usize;
 
-    fn from_index(u: u32) -> Self;
+    fn from_index(u: usize) -> Self;
 
     fn tag() -> &'static str;
 
@@ -302,7 +302,7 @@ impl<S: UnificationStore> UnificationTable<S> {
     /// Returns the keys of all variables created since the `snapshot`.
     pub fn vars_since_snapshot(&self, snapshot: &Snapshot<S>) -> Range<S::Key> {
         let range = self.values.values_since_snapshot(&snapshot.snapshot);
-        S::Key::from_index(range.start as u32)..S::Key::from_index(range.end as u32)
+        S::Key::from_index(range.start)..S::Key::from_index(range.end)
     }
 }
 
@@ -318,7 +318,7 @@ impl<S: UnificationStoreMut> UnificationTable<S> {
     /// Creates a fresh key with the given value.
     pub fn new_key(&mut self, value: S::Value) -> S::Key {
         let len = self.values.len();
-        let key: S::Key = UnifyKey::from_index(len as u32);
+        let key: S::Key = UnifyKey::from_index(len);
         self.values.push(VarValue::new_var(key, value));
         debug!("{}: created new key: {:?}", S::tag(), key);
         key
@@ -335,7 +335,7 @@ impl<S: UnificationStoreMut> UnificationTable<S> {
     /// the closure.
     pub fn reset_unifications(&mut self, mut value: impl FnMut(S::Key) -> S::Value) {
         self.values.reset_unifications(|i| {
-            let key = UnifyKey::from_index(i as u32);
+            let key = UnifyKey::from_index(i);
             let value = value(key);
             VarValue::new_var(key, value)
         });

--- a/src/unify/tests.rs
+++ b/src/unify/tests.rs
@@ -23,14 +23,14 @@ use unify::{EqUnifyValue, InPlace, InPlaceUnificationTable, NoError, UnifyKey, U
 use unify::{UnificationStore, UnificationTable};
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-struct UnitKey(u32);
+struct UnitKey(usize);
 
 impl UnifyKey for UnitKey {
     type Value = ();
-    fn index(&self) -> u32 {
+    fn index(&self) -> usize {
         self.0
     }
-    fn from_index(u: u32) -> UnitKey {
+    fn from_index(u: usize) -> UnitKey {
         UnitKey(u)
     }
     fn tag() -> &'static str {
@@ -242,14 +242,14 @@ fn even_odd() {
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-struct IntKey(u32);
+struct IntKey(usize);
 
 impl UnifyKey for IntKey {
     type Value = Option<i32>;
-    fn index(&self) -> u32 {
+    fn index(&self) -> usize {
         self.0
     }
-    fn from_index(u: u32) -> IntKey {
+    fn from_index(u: usize) -> IntKey {
         IntKey(u)
     }
     fn tag() -> &'static str {
@@ -363,17 +363,17 @@ fn unify_root_value_2() {
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-struct OrderedKey(u32);
+struct OrderedKey(usize);
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct OrderedRank(u32);
+struct OrderedRank(usize);
 
 impl UnifyKey for OrderedKey {
     type Value = OrderedRank;
-    fn index(&self) -> u32 {
+    fn index(&self) -> usize {
         self.0
     }
-    fn from_index(u: u32) -> OrderedKey {
+    fn from_index(u: usize) -> OrderedKey {
         OrderedKey(u)
     }
     fn tag() -> &'static str {

--- a/tests/external_undo_log.rs
+++ b/tests/external_undo_log.rs
@@ -9,14 +9,14 @@ use ena::{
 };
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
-struct IntKey(u32);
+struct IntKey(usize);
 
 impl UnifyKey for IntKey {
     type Value = Option<IntKey>;
-    fn index(&self) -> u32 {
+    fn index(&self) -> usize {
         self.0
     }
-    fn from_index(u: u32) -> IntKey {
+    fn from_index(u: usize) -> IntKey {
         IntKey(u)
     }
     fn tag() -> &'static str {


### PR DESCRIPTION
This allows for unioning bigger sets if necessary, but also doesn't necessarily change the storage size because it may still downsize to an u32 in from_index.

This shouldn't change anything to perf if the caller still uses u32 in their UnifyKey, considering that converting from usize to u32 was already done just before these function calls, and now it will be done just after, and they will likely be inlined.