### PR TITLE
remove feature `congruence-closure`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,9 @@ readme = "README.md"
 keywords = ["unification", "union-find"]
 
 [features]
-congruence-closure = [ "petgraph" ]
 bench = [ ]
 persistent = [ "dogged" ]
 
 [dependencies]
 dogged = { version = "0.2.0", optional = true }
 log = "0.4"
-petgraph = { version = "0.4.5", optional = true }


### PR DESCRIPTION
Removes just the declaration and the corresponding dependency from `Cargo.toml`. The code that was once guarded by this feature was removed years ago.

See 52cd081
See https://github.com/rust-lang/ena/pull/6