### PR TITLE
Fix doc typo in ena::unify

### DIFF
--- a/src/unify/mod.rs
+++ b/src/unify/mod.rs
@@ -304,7 +304,6 @@ impl<S: UnificationStoreBase> UnificationTable<S> {
 }
 
 impl<S: UnificationStoreMut> UnificationTable<S> {
-    /// Starts a new snapshot. Each snapshot must be either
     /// Creates a fresh key with the given value.
     pub fn new_key(&mut self, value: S::Value) -> S::Key {
         let len = self.values.len();


### PR DESCRIPTION
This appears to be a copy paste error.