### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 //! details.
 
 #![cfg_attr(feature = "bench", feature(test))]
+// This would add is_empty() functions to public traits
+#![allow(clippy::len_without_is_empty)]
 
 #[macro_use]
 extern crate log;

--- a/src/snapshot_vec.rs
+++ b/src/snapshot_vec.rs
@@ -165,10 +165,10 @@ impl<D: SnapshotVecDelegate, V: VecLike<D> + Default, L: Default> SnapshotVec<D,
 
 impl<D: SnapshotVecDelegate> SnapshotVecStorage<D> {
     /// Creates a `SnapshotVec` using the `undo_log`, allowing mutating methods to be called
-    pub fn with_log<'a, L>(
-        &'a mut self,
+    pub fn with_log<L>(
+        &mut self,
         undo_log: L,
-    ) -> SnapshotVec<D, &'a mut Vec<<D as SnapshotVecDelegate>::Value>, L>
+    ) -> SnapshotVec<D, &mut Vec<<D as SnapshotVecDelegate>::Value>, L>
     where
         L: UndoLogs<UndoLog<D>>,
     {

--- a/src/undo_log.rs
+++ b/src/undo_log.rs
@@ -40,7 +40,7 @@ pub trait UndoLogs<T> {
     }
 }
 
-impl<'a, T, U> UndoLogs<T> for &'a mut U
+impl<T, U> UndoLogs<T> for &mut U
 where
     U: UndoLogs<T>,
 {

--- a/tests/external_undo_log.rs
+++ b/tests/external_undo_log.rs
@@ -80,7 +80,7 @@ struct TypeVariableTable<'a> {
 }
 
 impl TypeVariableTable<'_> {
-    fn new(&mut self, i: i32) -> IntKey {
+    fn new_key(&mut self, i: i32) -> IntKey {
         self.storage.values.with_log(&mut self.undo_log).push(i);
         self.storage
             .eq_relations
@@ -93,18 +93,10 @@ struct Snapshot {
     undo_len: usize,
 }
 
+#[derive(Default)]
 struct TypeVariableUndoLogs {
     logs: Vec<UndoLog>,
     num_open_snapshots: usize,
-}
-
-impl Default for TypeVariableUndoLogs {
-    fn default() -> Self {
-        Self {
-            logs: Default::default(),
-            num_open_snapshots: Default::default(),
-        }
-    }
 }
 
 impl<T> UndoLogs<T> for TypeVariableUndoLogs
@@ -193,8 +185,8 @@ fn external_undo_log() {
     let mut undo_log = TypeVariableUndoLogs::default();
 
     let snapshot = undo_log.start_snapshot();
-    storage.with_log(&mut undo_log).new(1);
-    storage.with_log(&mut undo_log).new(2);
+    storage.with_log(&mut undo_log).new_key(1);
+    storage.with_log(&mut undo_log).new_key(2);
     assert_eq!(storage.len(), 2);
 
     undo_log.rollback_to(|| &mut storage, snapshot);


### PR DESCRIPTION
The notable functional change here is that the "Public API" comment is turned from a doc comment into a regular comment.  Previously it (along with all the forward slashes) was displaying awkwardly in the docs. Clippy was right in this case that the empty line indicated that it was not intended to attach to the item below.