### PR TITLE
Migrate to the 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.14.3"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 readme = "README.md"
 keywords = ["unification", "union-find"]
+edition = "2015"
 
 [features]
 bench = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.14.3"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 readme = "README.md"
 keywords = ["unification", "union-find"]
-edition = "2015"
+edition = "2018"
 
 [features]
 bench = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.14.3"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 readme = "README.md"
 keywords = ["unification", "union-find"]
-edition = "2018"
+edition = "2021"
 
 [features]
 bench = [ ]

--- a/src/snapshot_vec.rs
+++ b/src/snapshot_vec.rs
@@ -26,7 +26,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops;
 
-use undo_log::{Rollback, Snapshots, UndoLogs, VecLog};
+use crate::undo_log::{Rollback, Snapshots, UndoLogs, VecLog};
 
 #[derive(Debug)]
 pub enum UndoLog<D: SnapshotVecDelegate> {
@@ -132,7 +132,7 @@ where
 }
 
 // Snapshots are tokens that should be created/consumed linearly.
-pub struct Snapshot<S = ::undo_log::Snapshot> {
+pub struct Snapshot<S = crate::undo_log::Snapshot> {
     pub(crate) value_count: usize,
     snapshot: S,
 }

--- a/src/unify/backing_vec.rs
+++ b/src/unify/backing_vec.rs
@@ -1,10 +1,10 @@
+use crate::snapshot_vec as sv;
 #[cfg(feature = "persistent")]
 use dogged::DVec;
-use snapshot_vec as sv;
 use std::marker::PhantomData;
 use std::ops::{self, Range};
 
-use undo_log::{Rollback, Snapshots, UndoLogs, VecLog};
+use crate::undo_log::{Rollback, Snapshots, UndoLogs, VecLog};
 
 use super::{UnifyKey, UnifyValue, VarValue};
 

--- a/src/unify/mod.rs
+++ b/src/unify/mod.rs
@@ -35,8 +35,8 @@ use std::fmt::Debug;
 use std::marker;
 use std::ops::Range;
 
-use snapshot_vec::{self as sv, UndoLog};
-use undo_log::{UndoLogs, VecLog};
+use crate::snapshot_vec::{self as sv, UndoLog};
+use crate::undo_log::{UndoLogs, VecLog};
 
 mod backing_vec;
 pub use self::backing_vec::{

--- a/src/unify/tests.rs
+++ b/src/unify/tests.rs
@@ -16,11 +16,11 @@
 extern crate test;
 #[cfg(feature = "bench")]
 use self::test::Bencher;
+use crate::unify::{EqUnifyValue, InPlace, InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
+use crate::unify::{UnificationStore, UnificationTable};
 use std::cmp;
 #[cfg(feature = "persistent")]
 use unify::Persistent;
-use unify::{EqUnifyValue, InPlace, InPlaceUnificationTable, NoError, UnifyKey, UnifyValue};
-use unify::{UnificationStore, UnificationTable};
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 struct UnitKey(u32);


### PR DESCRIPTION
Currently the codebase does not specify an edition, which results in a warning and cargo uses the 2015 edition.  This PR takes the codebase to the 2021 edition in steps.  The first commit specifies the current 2015 edition.  The second commit specifies the 2018 edition, and updates the codebase to use the 2018 path conventions described at https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html.  The third commit bumps to the 2021 edition.  No code changes were required to support the 2021 edition.